### PR TITLE
ENH: Separate ``Space`` and ``SpatialReferences``

### DIFF
--- a/niworkflows/utils/spaces.py
+++ b/niworkflows/utils/spaces.py
@@ -220,6 +220,10 @@ class SpatialReferences:
     >>> sp.get_nonstd_spaces(dim=(3,))
     ['func', 'anat']
 
+    >>> sp.get_nonstd_spaces(only_names=False, dim=(3,))
+    [Space(name='func', cohort=None, spec={}),
+     Space(name='anat', cohort=None, spec={})]
+
     >>> sp.get_std_spaces()
     ['MNI152NLin2009cAsym', 'fsaverage', 'MNIPediatricAsym:cohort-2']
 
@@ -358,7 +362,8 @@ class SpatialReferences:
         return [s for s in self._spaces
                 if s.standard and s.spec and s.dim in dim]
 
-    def get_nonstd_spaces(self, dim=(2, 3)):
+    def get_nonstd_spaces(self, only_names=True, dim=(2, 3)):
         """Return nonstandard spaces."""
-        return [s.name for s in self._spaces
+        return [s.name if only_names else s
+                for s in self._spaces
                 if not s.standard and s.dim in dim]

--- a/niworkflows/utils/spaces.py
+++ b/niworkflows/utils/spaces.py
@@ -1,114 +1,364 @@
-"""Utilities for tracking and filtering spaces"""
+"""Utilities for tracking and filtering spaces."""
+import attr
+import typing
+from templateflow import api as _tfapi
+
+NONSTANDARD_REFERENCES = [
+    'T1w',
+    'T2w',
+    'anat',
+    'fsnative',
+    'func',
+    'run',
+    'sbref',
+    'session',
+]
+"""List of supported nonstandard reference spaces."""
+
 
 FSAVERAGE_DENSITY = {
-    '642': 'fsaverage3',
-    '2562': 'fsaverage4',
-    '10k': 'fsaverage5',
-    '41k': 'fsaverage6',
-    '164k': 'fsaverage',
+    'fsaverage3': '642',
+    'fsaverage4': '2562',
+    'fsaverage5': '10k',
+    'fsaverage6': '41k',
+    'fsaverage': '164k',
 }
-NONSTANDARD_REFERENCES = ['anat', 'T1w', 'run', 'func', 'sbref', 'session', 'fsnative']
+"""A map of surface densities and legacy fsaverageX names."""
 
 
-class Spaces:
-    """Helper class for managing fMRIPrep spaces."""
-    __slots__ = ('_output', '_internal')
+@attr.s(slots=True, frozen=True)
+class Space:
+    """
+    Represent a (non)standard space specification.
 
-    def __init__(self, output=None):
+    Examples
+    --------
+    >>> Space('MNI152NLin2009cAsym')
+    Space(name='MNI152NLin2009cAsym', cohort=None, spec={})
+
+    >>> Space('MNI152NLin2009cAsym', {})
+    Space(name='MNI152NLin2009cAsym', cohort=None, spec={})
+
+    >>> Space('MNI152NLin2009cAsym', None)
+    Space(name='MNI152NLin2009cAsym', cohort=None, spec={})
+
+    >>> Space('MNI152NLin2009cAsym', {'res': 1})
+    Space(name='MNI152NLin2009cAsym', cohort=None, spec={'res': 1})
+
+    >>> Space('MNIPediatricAsym', {'cohort': '1'})
+    Space(name='MNIPediatricAsym', cohort='1', spec={})
+
+    >>> Space('func')
+    Space(name='func', cohort=None, spec={})
+
+    Checks spaces with cohorts:
+    >>> Space('MNIPediatricAsym')
+    Traceback (most recent call last):
+      ...
+    ValueError: standard space "MNIPediatricAsym" is not fully defined.
+    ...
+
+    >>> Space(name='MNI152Lin', spec={'cohort': 1})
+    Traceback (most recent call last):
+      ...
+    ValueError: standard space "MNI152Lin" does not contain ...
+
+    >>> Space('MNIPediatricAsym', {'cohort': '100'})
+    Traceback (most recent call last):
+      ...
+    ValueError: standard space "MNIPediatricAsym" does not contain ...
+    ...
+
+    >>> Space('MNIPediatricAsym', 'blah')
+    Traceback (most recent call last):
+      ...
+    TypeError: invalid space specification...
+
+    >>> Space('shouldraise')
+    Traceback (most recent call last):
+      ...
+    ValueError: space identifier "shouldraise" is invalid.
+    ...
+
+    Correctly assigns the density of legacy "fsaverage":
+    >>> Space(name='fsaverage')
+    Space(name='fsaverage', cohort=None, spec={'den': '164k'})
+    >>> Space(name='fsaverage6')
+    Space(name='fsaverage', cohort=None, spec={'den': '41k'})
+
+    Overwrites density of legacy "fsaverage" specifications
+    >>> Space(name='fsaverage6', spec={'den': '10k'})
+    Space(name='fsaverage', cohort=None, spec={'den': '41k'})
+
+    >>> Space('func').standard
+    False
+
+    >>> Space('MNI152Lin').standard
+    True
+
+    >>> Space('MNIPediatricAsym', {'cohort': 1}).standard
+    True
+
+    >>> Space('func') == Space('func')
+    True
+
+    >>> Space('func') != Space('MNI152Lin')
+    True
+
+    >>> Space('MNI152Lin', {'res': 1}) == Space('MNI152Lin', {'res': 1})
+    True
+
+    >>> Space('MNI152Lin', {'res': 1}) == Space('MNI152Lin', {'res': 2})
+    False
+
+    >>> sp1 = Space('MNIPediatricAsym', {'cohort': 1})
+    >>> sp2 = Space('MNIPediatricAsym', {'cohort': 2})
+    >>> sp1 == sp2
+    False
+
+    >>> sp1 = Space('MNIPediatricAsym', {'res': 1, 'cohort': 1})
+    >>> sp2 = Space('MNIPediatricAsym', {'cohort': 1, 'res': 1})
+    >>> sp1 == sp2
+    True
+
+    """
+
+    _standard_spaces = tuple(_tfapi.templates())
+
+    name: str = attr.ib(default=None)
+    """Unique name designating this space."""
+    cohort: str = attr.ib(init=False, default=None)
+    """An attribute to accomodate cohorts from TemplateFlow."""
+    spec: typing.Dict = attr.ib(factory=dict)
+    """The dictionary of specs."""
+    standard: bool = attr.ib(default=False, repr=False)
+    """Whether this space is standard or not."""
+    dim: bool = attr.ib(default=3, repr=False)
+    """Dimensionality of the sampling manifold."""
+
+    def __attrs_post_init__(self):
+        """Extract cohort out of spec."""
+        if self.spec is None:
+            object.__setattr__(self, "spec", {})
+
+        if self.name.startswith('fsaverage'):
+            name = self.name
+            object.__setattr__(self, "name", "fsaverage")
+
+            if 'den' not in self.spec or name != "fsaverage":
+                spec = self.spec.copy()
+                spec['den'] = FSAVERAGE_DENSITY[name]
+                object.__setattr__(self, "spec", spec)
+
+        if self.name.startswith('fs'):
+            object.__setattr__(self, "dim", 2)
+
+        if self.name in self._standard_spaces:
+            object.__setattr__(self, "standard", True)
+
+        if self.spec and 'cohort' in self.spec:
+            spec = self.spec.copy()
+            value = spec.pop('cohort')
+            self._check_cohort('cohort', value)
+            object.__setattr__(self, "cohort", value)
+            object.__setattr__(self, "spec", spec)
+            return
+
+        _cohorts = _tfapi.TF_LAYOUT.get_cohorts(template=self.name)
+        if _cohorts:
+            _cohorts = ', '.join(['"cohort-%s"' % c for c in _cohorts])
+            raise ValueError(
+                'standard space "%s" is not fully defined.\n'
+                'Set a valid cohort selector from: %s.' % (self.name, _cohorts))
+
+    @name.validator
+    def _check_name(self, attribute, value):
+        if value.startswith('fsaverage'):
+            return
+        valid = list(self._standard_spaces) + NONSTANDARD_REFERENCES
+        if value not in valid:
+            raise ValueError(
+                'space identifier "%s" is invalid.\nValid '
+                'identifiers are: %s' % (value, ', '.join(valid)))
+
+    @cohort.validator
+    def _check_cohort(self, attribute, value):
+        valid = ['%s' % c for c in _tfapi.TF_LAYOUT.get_cohorts(
+            template=self.name)]
+        if value is not None and str(value) not in valid:
+            raise ValueError(
+                'standard space "%s" does not contain any cohort '
+                'named "%s".' % (self.name, value))
+
+    @spec.validator
+    def _check_spec(self, attribute, value):
+        if value is not None and not isinstance(value, dict):
+            raise TypeError(
+                "invalid space specification: %s." % str(value))
+
+
+class SpatialReferences:
+    """
+    Manage specifications of spatial references.
+
+    Examples
+    --------
+    >>> sp = SpatialReferences([
+    ...     'func',
+    ...     'fsnative',
+    ...     'MNI152NLin2009cAsym',
+    ...     'anat',
+    ...     'fsaverage5',
+    ...     'fsaverage6',
+    ...     ('MNIPediatricAsym', {'cohort': '2'}),
+    ...     ('MNI152NLin2009cAsym', {'res': 2}),
+    ...     ('MNI152NLin2009cAsym', {'res': 1}),
+    ... ])
+    >>> sp.get_nonstd_spaces()
+    ['func', 'fsnative', 'anat']
+
+    >>> sp.get_nonstd_spaces(dim=(3,))
+    ['func', 'anat']
+
+    >>> sp.get_std_spaces()
+    ['MNI152NLin2009cAsym', 'fsaverage', 'MNIPediatricAsym:cohort-2']
+
+    >>> sp.get_std_spaces(dim=(3,))
+    ['MNI152NLin2009cAsym', 'MNIPediatricAsym:cohort-2']
+
+    >>> sp.get_templates()
+    [Space(name='fsaverage', cohort=None, spec={'den': '10k'}),
+     Space(name='fsaverage', cohort=None, spec={'den': '41k'}),
+     Space(name='MNI152NLin2009cAsym', cohort=None, spec={'res': 2}),
+     Space(name='MNI152NLin2009cAsym', cohort=None, spec={'res': 1})]
+
+    >>> sp.add(('MNIPediatricAsym', {'cohort': '2'}))
+    >>> sp.get_std_spaces(dim=(3,))
+    ['MNI152NLin2009cAsym', 'MNIPediatricAsym:cohort-2']
+
+    >>> sp += [('MNIPediatricAsym', {'cohort': '2'})]
+    Traceback (most recent call last):
+      ...
+    ValueError: space ...
+
+    >>> sp += [('MNIPediatricAsym', {'cohort': '1'})]
+    >>> sp.get_std_spaces(dim=(3,))
+    ['MNI152NLin2009cAsym', 'MNIPediatricAsym:cohort-2', 'MNIPediatricAsym:cohort-1']
+
+    >>> sp.insert(0, ('MNIPediatricAsym', {'cohort': '3'}))
+    >>> sp.get_std_spaces(dim=(3,))
+    ['MNIPediatricAsym:cohort-3',
+     'MNI152NLin2009cAsym',
+     'MNIPediatricAsym:cohort-2',
+     'MNIPediatricAsym:cohort-1']
+
+    >>> sp.insert(0, ('MNIPediatricAsym', {'cohort': '3'}))
+    Traceback (most recent call last):
+      ...
+    ValueError: space ...
+
+    """
+
+    __slots__ = ('_spaces')
+    standard_spaces = tuple(_tfapi.templates())
+    """List of supported standard reference spaces."""
+
+    @staticmethod
+    def check_space(space):
+        """Build a :class:`Space` object."""
+        spec = {}
+        if not isinstance(space, str):
+            try:
+                spec = space[1] or {}
+            except IndexError:
+                pass
+            except TypeError:
+                space = (None, )
+
+            space = space[0]
+        return Space(space, spec)
+
+    def __init__(self, spaces=None):
         """
-        Tracks and distinguishes internal and output spaces.
+        Maintain the bookkeeping of spaces and templates.
 
         Internal spaces are normalizations required for pipeline execution which
         can vary based on user arguments.
         Output spaces are desired user outputs.
         """
-        self._output = []
-        self._internal = []
-        if output is not None:
-            self.output = output
+        self._spaces = []
+        if spaces is not None:
+            if isinstance(spaces, str):
+                spaces = [spaces]
+            self.__add__(spaces)
+
+    def __add__(self, b):
+        """Append a list of transforms to the internal list."""
+        if not isinstance(b, (list, tuple)):
+            raise TypeError('Must be a list.')
+
+        for space in b:
+            self.append(space)
+        return self
+
+    def __contains__(self, item):
+        """Implement the ``in`` builtin."""
+        if not self._spaces:
+            return False
+        item = self.check_space(item)
+        return any([i == item for i in self._spaces])
 
     def __repr__(self):
-        return 'Output spaces: %s\nInternal spaces: %s' % (self.output, self.internal)
+        """Representation of this object."""
+        return 'Imaging spaces: %s' % ', '.join(self._spaces)
 
     @property
-    def output(self):
-        return self._output
+    def spaces(self):
+        """Get all specified spaces."""
+        return self._spaces
 
-    @output.setter
-    def output(self, vals):
-        if not hasattr(vals, '__iter__'):
+    @spaces.setter
+    def spaces(self, value):
+        self._spaces = value
+
+    def add(self, value):
+        """Add one more space, without erroring if it exists."""
+        if value not in self:
+            self.spaces += [self.check_space(value)]
+
+    def append(self, value):
+        """Concatenate one more space."""
+        if value not in self:
+            self.spaces += [self.check_space(value)]
             return
-        for tpl, specs in vals:
-            self.add_space(tpl, specs=specs)
 
-    @property
-    def internal(self):
-        return self._internal
+        raise ValueError('space "%s" already in spaces.' % str(value))
 
-    @property
-    def all(self):
-        return self.output + self.internal
+    def insert(self, index, value, error=True):
+        """Concatenate one more space."""
+        if value not in self:
+            self.spaces.insert(index, self.check_space(value))
+        elif error is True:
+            raise ValueError('space "%s" already in spaces.' % str(value))
 
-    def unique(self, spaces='all'):
-        """Return unique spaces from an iterable composed of (template, specs) tuples"""
-        return {space[0] for space in getattr(self, spaces)}
+    def get_std_spaces(self, dim=(2, 3)):
+        """Return only standard spaces."""
+        _names = [':cohort-'.join((s.name, s.cohort))
+                  if s.cohort else s.name
+                  for s in self._spaces if s.standard and s.dim in dim]
 
-    def add_space(self, template, specs=None, output=True, strict=True):
-        if specs is None or not isinstance(specs, dict):
-            specs = {}
-        # map densities to fsaverage subject
-        if template == 'fsaverage' and specs.get('den') in FSAVERAGE_DENSITY:
-            template = FSAVERAGE_DENSITY[specs.get('den')]
-            del specs['den']
+        names = []
+        for s in _names:
+            if s not in names:
+                names.append(s)
+        return names
 
-        attr = self.output if output is True else self.internal
-        space = (template, specs)
-        if strict and space in self.all:
-            # avoid duplication
-            return
-        attr.append(space)
+    def get_templates(self, dim=(2, 3)):
+        """Return output spaces."""
+        return [s for s in self._spaces
+                if s.standard and s.spec and s.dim in dim]
 
-    def filtered(self, flt, spaces='all', name_only=False):
-        methods = {
-            'std': _filter_std,
-            'surf': _filter_surf,
-            'vol': _filter_vol,
-            'std_vol': _filter_std_vols,
-        }
-        if flt not in methods:
-            return
-        func = methods[flt]
-        filtered_spaces = [space for space in getattr(self, spaces) if func(space[0])]
-        if name_only:
-            filtered_spaces = [space for space, specs in filtered_spaces]
-        return filtered_spaces
-
-    def get_space(self, template, spaces='all', specs=None):
-        """
-        Query ``spaces`` and return the first matching ``template`` entry.
-        If no matches are found, returns ``None``.
-        """
-        for space in getattr(self, spaces):
-            if space[0] == template:
-                if specs is None or space[1] == specs:
-                    return space
-
-
-def _filter_std(space):
-    return space not in NONSTANDARD_REFERENCES
-
-
-def _filter_nstd(space):
-    return not _filter_std(space)
-
-
-def _filter_surf(space):
-    return space.startswith('fs')
-
-
-def _filter_vol(space):
-    return not _filter_surf(space)
-
-
-def _filter_std_vols(space):
-    return space not in NONSTANDARD_REFERENCES and not _filter_surf(space)
+    def get_nonstd_spaces(self, dim=(2, 3)):
+        """Return nonstandard spaces."""
+        return [s.name for s in self._spaces
+                if not s.standard and s.dim in dim]

--- a/setup.cfg
+++ b/setup.cfg
@@ -20,6 +20,7 @@ classifiers =
 [options]
 python_requires = >= 3.5
 install_requires =
+    attrs
     jinja2
     matplotlib >= 2.2.0 ; python_version >= "3.6"
     matplotlib >= 2.2.0, < 3.1 ; python_version < "3.6"
@@ -109,7 +110,7 @@ per-file-ignores =
 [tool:pytest]
 norecursedirs = .git
 addopts = -svx --doctest-modules
-doctest_optionflags = ALLOW_UNICODE NORMALIZE_WHITESPACE
+doctest_optionflags = ALLOW_UNICODE NORMALIZE_WHITESPACE ELLIPSIS
 env =
     PYTHONHASHSEED=0
 filterwarnings =


### PR DESCRIPTION
Okay, after much thinking, I believe this captures the whole set of requirements.

Now there is an ``Space`` object that makes all the validations and sanity checks. There is still room for enhancements:
- ~~We might want to implement a classmethod (something like ``Space.from_string``) that implements the parsing of ``--output-spaces`` arguments (see https://www.attrs.org/en/stable/init.html).~~ DONE
- We might want to check that the specs contain valid keywords against templateflow (at the moment, this is only done for cohort).

Other than that, I think the doctest examples show pretty much all the functionality.

Then, the ``SpatialReferences`` class is the one in charge of sorting out the available spaces. It has three convenience methods to filter out references:
- ``get_std_spaces()`` returns template names (including cohort if necessary) that is of interest to the spatial normalizations that sMRIPrep will run.
- ``get_templates()`` returns full ``Space`` objects with the desired outputs, as set by the user.
- ``get_nonstd_spaces()`` returns nonstandard ``Space``s or their names (depending on the ``only_names`` argument)
